### PR TITLE
Copyright, pcall to xpcall, model->folder

### DIFF
--- a/src/ServerStorage/Main.server.lua
+++ b/src/ServerStorage/Main.server.lua
@@ -1,11 +1,7 @@
 --[[
-	FolderTool
-
+	FolderTool™
 	A plugin to group selected items to a folder and ungroup them.
-
 	Created by GamersInternational and LucasTutoriaisSaimo for Rii-built Studios
-
-	(C) 2021
 ]]
 
 local SelectionService = game:GetService("Selection")
@@ -30,28 +26,22 @@ Button_GroupIntoFolder.Click:Connect(function()
 	local selectedObjects = SelectionService:Get()
 
 	if #selectedObjects == 0 then
-		warn("You must have at least one Instance to group.")
+		warn("FolderTool | You must have at least one Instance to group.")
 		return
 	end
-	
-	local sucess = pcall(function()
-		--\\ Some instances can't be moved. We check that using a pcall.
-		
+
+	xpcall(function()
+		--\\ Some instances can't be moved. We check that using xpcall.
 		for _, child in ipairs(selectedObjects) do
 			child.Parent = child.Parent
 		end
-	end)
-	
-	if not sucess then
-		warn("One item is not movable. Please un-select any services / any special Instances.")
-		return;
-	end
-	
-	local folder = Instance.new("Folder", selectedObjects[1].Parent)
+	end, function() warn("FolderTool | One item is not moveable. Please de-select any services / any special Instances.") end)
+
+	local folder = Instance.new("Folder")
+	folder.Parent = selectedObjects[1].Parent
 	for _, child in ipairs(selectedObjects) do
 		child.Parent = folder
 	end
-	
 	ChangeHistoryService:SetWaypoint("FolderTool: Grouped items into a folder")
 end)
 
@@ -59,19 +49,19 @@ Button_UngroupFromFolder.Click:Connect(function()
 	local selectedObjects = SelectionService:Get()
 
 	if #selectedObjects == 0 then
-		warn("You need to select a folder first!")
+		warn("FolderTool | You need to select a folder first!")
 		return;
 	end
-	
+
 	for _, child in ipairs(selectedObjects) do
 		if not child:IsA("Folder") then
-			warn("You can only un-group folders.")
+			warn("FolderTool | You can only un-group folders.")
 			return
 		end
-		
+
 		--\\ Validation, just making sure every children is a folder.
 	end
-	
+
 	for _, folder in ipairs(selectedObjects) do
 		for _, child in ipairs(folder:GetChildren()) do
 			child.Parent = folder.Parent
@@ -82,6 +72,6 @@ Button_UngroupFromFolder.Click:Connect(function()
 		--   Because then, you can't click CTRL + Z to un-do it, as the folder is now locked, sadly.
 		--   However, this shouldn't have that big of a performance implication.
 	end
-	
+
 	ChangeHistoryService:SetWaypoint("FolderTool: Un-grouped items from a folder")
 end)

--- a/src/ServerStorage/Main.server.lua
+++ b/src/ServerStorage/Main.server.lua
@@ -21,6 +21,13 @@ local Button_UngroupFromFolder = Toolbar:CreateButton(
 	"rbxassetid://7081124672"
 )
 
+local Button_ModelToFolder = Toolbar:CreateButton(
+    "Convert a selected model into a folder",
+    "This button coverts a model into a folder. Some properties will be discarded.",
+    "rbxassetid://7081112821" --TODO: image
+)
+
+
 
 Button_GroupIntoFolder.Click:Connect(function()
 	local selectedObjects = SelectionService:Get()
@@ -74,4 +81,35 @@ Button_UngroupFromFolder.Click:Connect(function()
 	end
 
 	ChangeHistoryService:SetWaypoint("FolderTool: Un-grouped items from a folder")
+end)
+
+Button_ModelToFolder.Click:Connect(function() -- thanks Dandcx
+    local selectedObjects = SelectionService:Get()
+
+	if #selectedObjects == 0 then
+		warn("FolderTool | You need to select a folder first!")
+		return;
+	end
+    local toSelect = {}
+	for _, child in ipairs(selectedObjects) do
+		if not child:IsA("Model") then
+			warn("FolderTool | You can only convert models to folders (not vice versa).")
+			return
+		end
+		--\\ Validation, just making sure every children is a model.
+
+        for _, model in ipairs(selectedObjects) do
+            local modChildren = model:GetChildren()
+            local newFolder = Instance.new("Folder")
+            newFolder.Name = model.Name
+            newFolder.Parent = model.Parent
+            for _, c in ipairs(modChildren) do
+                c.Parent = newFolder
+            end
+            table.insert(toSelect, newFolder)
+            model.Parent = nil
+        end
+	end
+    SelectionService:Set(toSelect)
+    ChangeHistoryService:SetWaypoint("FolderTool: Model to folder")
 end)


### PR DESCRIPTION
Replaced false copyright with (somewhat) enforceable trademark. Also replaced pcall with more fitting xpcall, made the model to folder function as suggested by Dandcx, and fixed spelling errors.